### PR TITLE
*: Use new row format to communicate with storage

### DIFF
--- a/executor/batch_checker.go
+++ b/executor/batch_checker.go
@@ -55,7 +55,8 @@ func encodeNewRow(ctx sessionctx.Context, t table.Table, row []types.Datum) ([]b
 			skimmedRow = append(skimmedRow, row[col.Offset])
 		}
 	}
-	newRowValue, err := tablecodec.EncodeRow(ctx.GetSessionVars().StmtCtx, skimmedRow, colIDs, nil, nil)
+	rd := &ctx.GetSessionVars().RowEncoder
+	newRowValue, err := tablecodec.EncodeRow(ctx.GetSessionVars().StmtCtx, skimmedRow, colIDs, nil, nil, rd)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/mem_reader.go
+++ b/executor/mem_reader.go
@@ -251,14 +251,6 @@ func getRowData(
 	return buffer.rd.DecodeToBytes(colIDs, handle, value, buffer.handleBytes)
 }
 
-func hasColVal(data [][]byte, colIDs map[int64]int, id int64) bool {
-	offset, ok := colIDs[id]
-	if ok && data[offset] != nil {
-		return true
-	}
-	return false
-}
-
 type processKVFunc func(key, value []byte) error
 
 func iterTxnMemBuffer(ctx sessionctx.Context, kvRanges []kv.KeyRange, fn processKVFunc) error {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/rowcodec"
 )
 
 // Error instances.
@@ -313,6 +314,9 @@ type SessionVars struct {
 
 	// replicaRead is used for reading data from replicas, only follower is supported at this time.
 	replicaRead kv.ReplicaReadType
+
+	// RowEncoder is reused in session for encode row data.
+	RowEncoder rowcodec.Encoder
 }
 
 // ConnectionInfo present connection used by audit.

--- a/store/mockstore/mocktikv/cluster_test.go
+++ b/store/mockstore/mocktikv/cluster_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/rowcodec"
 )
 
 var _ = Suite(&testClusterSuite{})
@@ -57,7 +58,8 @@ func (s *testClusterSuite) TestClusterSplit(c *C) {
 		rowKey := tablecodec.EncodeRowKeyWithHandle(tblID, handle)
 		colValue := types.NewStringDatum(strconv.Itoa(int(handle)))
 		// TODO: Should use session's TimeZone instead of UTC.
-		rowValue, err1 := tablecodec.EncodeRow(sc, []types.Datum{colValue}, []int64{colID}, nil, nil)
+		rd := &rowcodec.Encoder{}
+		rowValue, err1 := tablecodec.EncodeRow(sc, []types.Datum{colValue}, []int64{colID}, nil, nil, rd)
 		c.Assert(err1, IsNil)
 		txn.Set(rowKey, rowValue)
 

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/rowcodec"
 
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -170,12 +171,35 @@ func (h *rpcHandler) buildTableScan(ctx *dagContext, executor *tipb.Executor) (*
 	if startTS == 0 {
 		startTS = ctx.dagReq.GetStartTsFallback()
 	}
+	colInfos := make([]rowcodec.ColInfo, len(columns))
+	for i := range colInfos {
+		col := columns[i]
+		colInfos[i] = rowcodec.ColInfo{
+			ID:         col.ColumnId,
+			Tp:         col.Tp,
+			Flag:       col.Flag,
+			IsPKHandle: col.GetPkHandle(),
+		}
+	}
+	defVal := func(i int) ([]byte, error) {
+		col := columns[i]
+		if col.DefaultVal == nil {
+			return nil, nil
+		}
+		// col.DefaultVal always be  varint `[flag]+[value]`.
+		if len(col.DefaultVal) < 1 {
+			panic("invalid default value")
+		}
+		return col.DefaultVal, nil
+	}
+	rd := rowcodec.NewByteDecoder(colInfos, -1, defVal, nil)
 	e := &tableScanExec{
 		TableScan: executor.TblScan,
 		kvRanges:  ranges,
 		colIDs:    ctx.evalCtx.colIDs,
 		startTS:   startTS,
 		mvccStore: h.mvccStore,
+		rd:        rd,
 	}
 	if ctx.dagReq.CollectRangeCounts != nil && *ctx.dagReq.CollectRangeCounts {
 		e.counts = make([]int64, len(ranges))

--- a/store/mockstore/mocktikv/executor.go
+++ b/store/mockstore/mocktikv/executor.go
@@ -517,14 +517,6 @@ func (e *limitExec) Next(ctx context.Context) (value [][]byte, err error) {
 	return value, nil
 }
 
-func hasColVal(data [][]byte, colIDs map[int64]int, id int64) bool {
-	offset, ok := colIDs[id]
-	if ok && data[offset] != nil {
-		return true
-	}
-	return false
-}
-
 // getRowData decodes raw byte slice to row data.
 func getRowData(
 	columns []*tipb.ColumnInfo,

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -272,7 +272,8 @@ func (t *TableCommon) UpdateRecord(ctx sessionctx.Context, h int64, oldData, new
 	key := t.RecordKey(h)
 	sessVars := ctx.GetSessionVars()
 	sc := sessVars.StmtCtx
-	value, err := tablecodec.EncodeRow(sc, row, colIDs, nil, nil)
+	rd := &sessVars.RowEncoder
+	value, err := tablecodec.EncodeRow(sc, row, colIDs, nil, nil, rd)
 	if err != nil {
 		return err
 	}
@@ -477,7 +478,8 @@ func (t *TableCommon) AddRecord(ctx sessionctx.Context, r []types.Datum, opts ..
 	adjustRowValuesBuf(writeBufs, len(row))
 	key := t.RecordKey(recordID)
 	sc := sessVars.StmtCtx
-	writeBufs.RowValBuf, err = tablecodec.EncodeRow(sc, row, colIDs, writeBufs.RowValBuf, writeBufs.AddRowValues)
+	rd := &sessVars.RowEncoder
+	writeBufs.RowValBuf, err = tablecodec.EncodeRow(sc, row, colIDs, writeBufs.RowValBuf, writeBufs.AddRowValues, rd)
 	if err != nil {
 		return 0, err
 	}

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -52,12 +52,6 @@ func (s *testTableCodecSuite) TestTableCodec(c *C) {
 	c.Assert(h, Equals, int64(2))
 }
 
-// column is a structure used for test
-type column struct {
-	id int64
-	tp *types.FieldType
-}
-
 func (s *testTableCodecSuite) TestCutKeyNew(c *C) {
 	values := []types.Datum{types.NewIntDatum(1), types.NewBytesDatum([]byte("abc")), types.NewFloat64Datum(5.5)}
 	handle := types.NewIntDatum(100)

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/rowcodec"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -81,7 +82,8 @@ func (s *testTableCodecSuite) TestCutRow(c *C) {
 	for _, col := range cols {
 		colIDs = append(colIDs, col.id)
 	}
-	bs, err := EncodeRow(sc, row, colIDs, nil, nil)
+	rd := &rowcodec.Encoder{}
+	bs, err := EncodeRow(sc, row, colIDs, nil, nil, rd)
 	c.Assert(err, IsNil)
 	c.Assert(bs, NotNil)
 

--- a/util/rowDecoder/decoder.go
+++ b/util/rowDecoder/decoder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/rowcodec"
 )
 
 // Column contains the info and generated expr of column.
@@ -45,7 +46,12 @@ func NewRowDecoder(tbl table.Table, decodeColMap map[int64]Column) *RowDecoder {
 
 // DecodeAndEvalRowWithMap decodes a byte slice into datums and evaluates the generated column value.
 func (rd *RowDecoder) DecodeAndEvalRowWithMap(ctx sessionctx.Context, handle int64, b []byte, decodeLoc, sysLoc *time.Location, row map[int64]types.Datum) (map[int64]types.Datum, error) {
-	row, err := tablecodec.DecodeRowWithMap(b, rd.colTypes, decodeLoc, row)
+	var err error
+	if !rowcodec.IsNewFormat(b) {
+		row, err = tablecodec.DecodeRowWithMap(b, rd.colTypes, decodeLoc, row)
+	} else {
+		row, err = tablecodec.DecodeRowWithMapNew(b, rd.colTypes, decodeLoc, row)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/util/rowcodec/bench_test.go
+++ b/util/rowcodec/bench_test.go
@@ -17,9 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/parser/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/rowcodec"
@@ -34,23 +32,6 @@ func BenchmarkEncode(b *testing.B) {
 	var err error
 	for i := 0; i < b.N; i++ {
 		buf, err = xb.Encode(nil, colIDs, oldRow, buf)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkEncodeFromOldRow(b *testing.B) {
-	b.ReportAllocs()
-	oldRow := types.MakeDatums(1, "abc", 1.1)
-	oldRowData, err := tablecodec.EncodeRow(new(stmtctx.StatementContext), oldRow, []int64{1, 2, 3}, nil, nil)
-	if err != nil {
-		b.Fatal(err)
-	}
-	var xb rowcodec.Encoder
-	var buf []byte
-	for i := 0; i < b.N; i++ {
-		buf, err = rowcodec.EncodeFromOldRow(&xb, nil, oldRowData, buf)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/util/rowcodec/bench_test.go
+++ b/util/rowcodec/bench_test.go
@@ -1,0 +1,94 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/rowcodec"
+)
+
+func BenchmarkEncode(b *testing.B) {
+	b.ReportAllocs()
+	oldRow := types.MakeDatums(1, "abc", 1.1)
+	var xb rowcodec.Encoder
+	var buf []byte
+	colIDs := []int64{1, 2, 3}
+	var err error
+	for i := 0; i < b.N; i++ {
+		buf, err = xb.Encode(nil, colIDs, oldRow, buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeFromOldRow(b *testing.B) {
+	b.ReportAllocs()
+	oldRow := types.MakeDatums(1, "abc", 1.1)
+	oldRowData, err := tablecodec.EncodeRow(new(stmtctx.StatementContext), oldRow, []int64{1, 2, 3}, nil, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var xb rowcodec.Encoder
+	var buf []byte
+	for i := 0; i < b.N; i++ {
+		buf, err = rowcodec.EncodeFromOldRow(&xb, nil, oldRowData, buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	b.ReportAllocs()
+	oldRow := types.MakeDatums(1, "abc", 1.1)
+	colIDs := []int64{-1, 2, 3}
+	tps := []*types.FieldType{
+		types.NewFieldType(mysql.TypeLonglong),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeDouble),
+	}
+	var xb rowcodec.Encoder
+	xRowData, err := xb.Encode(nil, colIDs, oldRow, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	cols := make([]rowcodec.ColInfo, len(tps))
+	for i, tp := range tps {
+		cols[i] = rowcodec.ColInfo{
+			ID:      colIDs[i],
+			Tp:      int32(tp.Tp),
+			Flag:    int32(tp.Flag),
+			Flen:    tp.Flen,
+			Decimal: tp.Decimal,
+			Elems:   tp.Elems,
+		}
+	}
+	decoder := rowcodec.NewChunkDecoder(cols, -1, nil, time.Local)
+	chk := chunk.NewChunkWithCapacity(tps, 1)
+	for i := 0; i < b.N; i++ {
+		chk.Reset()
+		err = decoder.DecodeToChunk(xRowData, 1, chk)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/util/rowcodec/common.go
+++ b/util/rowcodec/common.go
@@ -1,0 +1,230 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec
+
+import (
+	"encoding/binary"
+	"reflect"
+	"unsafe"
+
+	"github.com/pingcap/errors"
+)
+
+// CodecVer is the constant number that represent the new row format.
+const CodecVer = 128
+
+var errInvalidCodecVer = errors.New("invalid codec version")
+
+// First byte in the encoded value which specifies the encoding type.
+const (
+	NilFlag          byte = 0
+	BytesFlag        byte = 1
+	CompactBytesFlag byte = 2
+	IntFlag          byte = 3
+	UintFlag         byte = 4
+	FloatFlag        byte = 5
+	DecimalFlag      byte = 6
+	VarintFlag       byte = 8
+	VaruintFlag      byte = 9
+	JSONFlag         byte = 10
+)
+
+func bytesToU32Slice(b []byte) []uint32 {
+	if len(b) == 0 {
+		return nil
+	}
+	var u32s []uint32
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u32s))
+	hdr.Len = len(b) / 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
+	return u32s
+}
+
+func bytes2U16Slice(b []byte) []uint16 {
+	if len(b) == 0 {
+		return nil
+	}
+	var u16s []uint16
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u16s))
+	hdr.Len = len(b) / 2
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
+	return u16s
+}
+
+func u16SliceToBytes(u16s []uint16) []byte {
+	if len(u16s) == 0 {
+		return nil
+	}
+	var b []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	hdr.Len = len(u16s) * 2
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&u16s[0]))
+	return b
+}
+
+func u32SliceToBytes(u32s []uint32) []byte {
+	if len(u32s) == 0 {
+		return nil
+	}
+	var b []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	hdr.Len = len(u32s) * 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&u32s[0]))
+	return b
+}
+
+func encodeInt(buf []byte, iVal int64) []byte {
+	var tmp [8]byte
+	if int64(int8(iVal)) == iVal {
+		buf = append(buf, byte(iVal))
+	} else if int64(int16(iVal)) == iVal {
+		binary.LittleEndian.PutUint16(tmp[:], uint16(iVal))
+		buf = append(buf, tmp[:2]...)
+	} else if int64(int32(iVal)) == iVal {
+		binary.LittleEndian.PutUint32(tmp[:], uint32(iVal))
+		buf = append(buf, tmp[:4]...)
+	} else {
+		binary.LittleEndian.PutUint64(tmp[:], uint64(iVal))
+		buf = append(buf, tmp[:8]...)
+	}
+	return buf
+}
+
+func decodeInt(val []byte) int64 {
+	switch len(val) {
+	case 1:
+		return int64(int8(val[0]))
+	case 2:
+		return int64(int16(binary.LittleEndian.Uint16(val)))
+	case 4:
+		return int64(int32(binary.LittleEndian.Uint32(val)))
+	default:
+		return int64(binary.LittleEndian.Uint64(val))
+	}
+}
+
+func encodeUint(buf []byte, uVal uint64) []byte {
+	var tmp [8]byte
+	if uint64(uint8(uVal)) == uVal {
+		buf = append(buf, byte(uVal))
+	} else if uint64(uint16(uVal)) == uVal {
+		binary.LittleEndian.PutUint16(tmp[:], uint16(uVal))
+		buf = append(buf, tmp[:2]...)
+	} else if uint64(uint32(uVal)) == uVal {
+		binary.LittleEndian.PutUint32(tmp[:], uint32(uVal))
+		buf = append(buf, tmp[:4]...)
+	} else {
+		binary.LittleEndian.PutUint64(tmp[:], uint64(uVal))
+		buf = append(buf, tmp[:8]...)
+	}
+	return buf
+}
+
+func decodeUint(val []byte) uint64 {
+	switch len(val) {
+	case 1:
+		return uint64(val[0])
+	case 2:
+		return uint64(binary.LittleEndian.Uint16(val))
+	case 4:
+		return uint64(binary.LittleEndian.Uint32(val))
+	default:
+		return binary.LittleEndian.Uint64(val)
+	}
+}
+
+type largeNotNullSorter Encoder
+
+func (s *largeNotNullSorter) Less(i, j int) bool {
+	return s.colIDs32[i] < s.colIDs32[j]
+}
+
+func (s *largeNotNullSorter) Len() int {
+	return int(s.numNotNullCols)
+}
+
+func (s *largeNotNullSorter) Swap(i, j int) {
+	s.colIDs32[i], s.colIDs32[j] = s.colIDs32[j], s.colIDs32[i]
+	s.values[i], s.values[j] = s.values[j], s.values[i]
+}
+
+type smallNotNullSorter Encoder
+
+func (s *smallNotNullSorter) Less(i, j int) bool {
+	return s.colIDs[i] < s.colIDs[j]
+}
+
+func (s *smallNotNullSorter) Len() int {
+	return int(s.numNotNullCols)
+}
+
+func (s *smallNotNullSorter) Swap(i, j int) {
+	s.colIDs[i], s.colIDs[j] = s.colIDs[j], s.colIDs[i]
+	s.values[i], s.values[j] = s.values[j], s.values[i]
+}
+
+type smallNullSorter Encoder
+
+func (s *smallNullSorter) Less(i, j int) bool {
+	nullCols := s.colIDs[s.numNotNullCols:]
+	return nullCols[i] < nullCols[j]
+}
+
+func (s *smallNullSorter) Len() int {
+	return int(s.numNullCols)
+}
+
+func (s *smallNullSorter) Swap(i, j int) {
+	nullCols := s.colIDs[s.numNotNullCols:]
+	nullCols[i], nullCols[j] = nullCols[j], nullCols[i]
+}
+
+type largeNullSorter Encoder
+
+func (s *largeNullSorter) Less(i, j int) bool {
+	nullCols := s.colIDs32[s.numNotNullCols:]
+	return nullCols[i] < nullCols[j]
+}
+
+func (s *largeNullSorter) Len() int {
+	return int(s.numNullCols)
+}
+
+func (s *largeNullSorter) Swap(i, j int) {
+	nullCols := s.colIDs32[s.numNotNullCols:]
+	nullCols[i], nullCols[j] = nullCols[j], nullCols[i]
+}
+
+const (
+	// Length of rowkey.
+	rowKeyLen = 19
+	// Index of record flag 'r' in rowkey used by master tidb-server.
+	// The rowkey format is t{8 bytes id}_r{8 bytes handle}
+	recordPrefixIdx = 10
+)
+
+// IsRowKey determine whether key is row key.
+// this method will be used in unistore.
+func IsRowKey(key []byte) bool {
+	return len(key) == rowKeyLen && key[0] == 't' && key[recordPrefixIdx] == 'r'
+}
+
+// IsNewFormat checks whether row data is in new-format.
+func IsNewFormat(rowData []byte) bool {
+	return rowData[0] == CodecVer
+}

--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -1,0 +1,444 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
+)
+
+// decoder contains base util for decode row.
+type decoder struct {
+	row
+	columns     []ColInfo
+	handleColID int64
+	loc         *time.Location
+}
+
+// NewDecoder creates a decoder.
+func NewDecoder(columns []ColInfo, handleColID int64, loc *time.Location) *decoder {
+	return &decoder{
+		columns:     columns,
+		handleColID: handleColID,
+		loc:         loc,
+	}
+}
+
+// ColInfo is used as column meta info for row decoder.
+type ColInfo struct {
+	ID         int64
+	Tp         int32
+	Flag       int32
+	IsPKHandle bool
+
+	Flen    int
+	Decimal int
+	Elems   []string
+}
+
+// DatumMapDecoder decodes the row to datum map.
+type DatumMapDecoder struct {
+	decoder
+}
+
+// NewDatumMapDecoder creates a DatumMapDecoder.
+func NewDatumMapDecoder(columns []ColInfo, handleColID int64, loc *time.Location) *DatumMapDecoder {
+	return &DatumMapDecoder{decoder{
+		columns:     columns,
+		handleColID: handleColID,
+		loc:         loc,
+	}}
+}
+
+// DecodeToDatumMap decodes byte slices to datum map.
+func (decoder *DatumMapDecoder) DecodeToDatumMap(rowData []byte, handle int64, row map[int64]types.Datum) (map[int64]types.Datum, error) {
+	if row == nil {
+		row = make(map[int64]types.Datum, len(decoder.columns))
+	}
+	err := decoder.fromBytes(rowData)
+	if err != nil {
+		return nil, err
+	}
+	for _, col := range decoder.columns {
+		if col.ID == decoder.handleColID {
+			row[col.ID] = types.NewIntDatum(handle)
+			continue
+		}
+		idx, isNil, notFound := decoder.row.findColID(col.ID)
+		if !notFound && !isNil {
+			colData := decoder.getData(idx)
+			d, err := decoder.decodeColDatum(&col, colData)
+			if err != nil {
+				return nil, err
+			}
+			row[col.ID] = d
+			continue
+		}
+
+		if isNil {
+			var d types.Datum
+			d.SetNull()
+			row[col.ID] = d
+			continue
+		}
+	}
+	return row, nil
+}
+
+func (decoder *DatumMapDecoder) decodeColDatum(col *ColInfo, colData []byte) (types.Datum, error) {
+	var d types.Datum
+	switch byte(col.Tp) {
+	case mysql.TypeLonglong, mysql.TypeLong, mysql.TypeInt24, mysql.TypeShort, mysql.TypeTiny, mysql.TypeYear:
+		if mysql.HasUnsignedFlag(uint(col.Flag)) {
+			d.SetUint64(decodeUint(colData))
+		} else {
+			d.SetInt64(decodeInt(colData))
+		}
+	case mysql.TypeFloat:
+		_, fVal, err := codec.DecodeFloat(colData)
+		if err != nil {
+			return d, err
+		}
+		d.SetFloat32(float32(fVal))
+	case mysql.TypeDouble:
+		_, fVal, err := codec.DecodeFloat(colData)
+		if err != nil {
+			return d, err
+		}
+		d.SetFloat64(fVal)
+	case mysql.TypeVarString, mysql.TypeVarchar, mysql.TypeString,
+		mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		d.SetBytes(colData)
+	case mysql.TypeNewDecimal:
+		_, dec, _, _, err := codec.DecodeDecimal(colData)
+		if err != nil {
+			return d, err
+		}
+		d.SetMysqlDecimal(dec)
+	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
+		var t types.Time
+		t.Type = uint8(col.Tp)
+		t.Fsp = int8(col.Decimal)
+		err := t.FromPackedUint(decodeUint(colData))
+		if err != nil {
+			return d, err
+		}
+		if byte(col.Tp) == mysql.TypeTimestamp && !t.IsZero() {
+			err = t.ConvertTimeZone(time.UTC, decoder.loc)
+			if err != nil {
+				return d, err
+			}
+		}
+		d.SetMysqlTime(t)
+	case mysql.TypeDuration:
+		var dur types.Duration
+		dur.Duration = time.Duration(decodeInt(colData))
+		dur.Fsp = int8(col.Decimal)
+		d.SetMysqlDuration(dur)
+	case mysql.TypeEnum:
+		// ignore error deliberately, to read empty enum value.
+		enum, err := types.ParseEnumValue(col.Elems, decodeUint(colData))
+		if err != nil {
+			enum = types.Enum{}
+		}
+		d.SetMysqlEnum(enum)
+	case mysql.TypeSet:
+		set, err := types.ParseSetValue(col.Elems, decodeUint(colData))
+		if err != nil {
+			return d, err
+		}
+		d.SetMysqlSet(set)
+	case mysql.TypeBit:
+		byteSize := (col.Flen + 7) >> 3
+		d.SetMysqlBit(types.NewBinaryLiteralFromUint(decodeUint(colData), byteSize))
+	case mysql.TypeJSON:
+		var j json.BinaryJSON
+		j.TypeCode = colData[0]
+		j.Value = colData[1:]
+		d.SetMysqlJSON(j)
+	default:
+		return d, errors.Errorf("unknown type %d", col.Tp)
+	}
+	return d, nil
+}
+
+// ChunkDecoder decodes the row to chunk.Chunk.
+type ChunkDecoder struct {
+	decoder
+	defDatum func(i int) (types.Datum, error)
+}
+
+// NewChunkDecoder creates a NewChunkDecoder.
+func NewChunkDecoder(columns []ColInfo, handleColID int64, defDatum func(i int) (types.Datum, error), loc *time.Location) *ChunkDecoder {
+	return &ChunkDecoder{
+		decoder: decoder{
+			columns:     columns,
+			handleColID: handleColID,
+			loc:         loc,
+		},
+		defDatum: defDatum,
+	}
+}
+
+// DecodeToChunk decodes a row to chunk.
+func (decoder *ChunkDecoder) DecodeToChunk(rowData []byte, handle int64, chk *chunk.Chunk) error {
+	err := decoder.fromBytes(rowData)
+	if err != nil {
+		return err
+	}
+
+	for colIdx, col := range decoder.columns {
+		if col.ID == decoder.handleColID {
+			chk.AppendInt64(colIdx, handle)
+			continue
+		}
+
+		idx, isNil, notFound := decoder.row.findColID(col.ID)
+		if !notFound && !isNil {
+			colData := decoder.getData(idx)
+			err := decoder.decodeColToChunk(colIdx, &col, colData, chk)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		if isNil {
+			chk.AppendNull(colIdx)
+			continue
+		}
+
+		if decoder.defDatum == nil {
+			chk.AppendNull(colIdx)
+			continue
+		}
+
+		defDatum, err := decoder.defDatum(colIdx)
+		if err != nil {
+			return err
+		}
+
+		chk.AppendDatum(colIdx, &defDatum)
+	}
+	return nil
+}
+
+func (decoder *ChunkDecoder) decodeColToChunk(colIdx int, col *ColInfo, colData []byte, chk *chunk.Chunk) error {
+	switch byte(col.Tp) {
+	case mysql.TypeLonglong, mysql.TypeLong, mysql.TypeInt24, mysql.TypeShort, mysql.TypeTiny, mysql.TypeYear:
+		if mysql.HasUnsignedFlag(uint(col.Flag)) {
+			chk.AppendUint64(colIdx, decodeUint(colData))
+		} else {
+			chk.AppendInt64(colIdx, decodeInt(colData))
+		}
+	case mysql.TypeFloat:
+		_, fVal, err := codec.DecodeFloat(colData)
+		if err != nil {
+			return err
+		}
+		chk.AppendFloat32(colIdx, float32(fVal))
+	case mysql.TypeDouble:
+		_, fVal, err := codec.DecodeFloat(colData)
+		if err != nil {
+			return err
+		}
+		chk.AppendFloat64(colIdx, fVal)
+	case mysql.TypeVarString, mysql.TypeVarchar, mysql.TypeString,
+		mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		chk.AppendBytes(colIdx, colData)
+	case mysql.TypeNewDecimal:
+		_, dec, _, _, err := codec.DecodeDecimal(colData)
+		if err != nil {
+			return err
+		}
+		chk.AppendMyDecimal(colIdx, dec)
+	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
+		var t types.Time
+		t.Type = uint8(col.Tp)
+		t.Fsp = int8(col.Decimal)
+		err := t.FromPackedUint(decodeUint(colData))
+		if err != nil {
+			return err
+		}
+		if byte(col.Tp) == mysql.TypeTimestamp && decoder.loc != nil && !t.IsZero() {
+			err = t.ConvertTimeZone(time.UTC, decoder.loc)
+			if err != nil {
+				return err
+			}
+		}
+		chk.AppendTime(colIdx, t)
+	case mysql.TypeDuration:
+		var dur types.Duration
+		dur.Duration = time.Duration(decodeInt(colData))
+		dur.Fsp = int8(col.Decimal)
+		chk.AppendDuration(colIdx, dur)
+	case mysql.TypeEnum:
+		// ignore error deliberately, to read empty enum value.
+		enum, err := types.ParseEnumValue(col.Elems, decodeUint(colData))
+		if err != nil {
+			enum = types.Enum{}
+		}
+		chk.AppendEnum(colIdx, enum)
+	case mysql.TypeSet:
+		set, err := types.ParseSetValue(col.Elems, decodeUint(colData))
+		if err != nil {
+			return err
+		}
+		chk.AppendSet(colIdx, set)
+	case mysql.TypeBit:
+		byteSize := (col.Flen + 7) >> 3
+		chk.AppendBytes(colIdx, types.NewBinaryLiteralFromUint(decodeUint(colData), byteSize))
+	case mysql.TypeJSON:
+		var j json.BinaryJSON
+		j.TypeCode = colData[0]
+		j.Value = colData[1:]
+		chk.AppendJSON(colIdx, j)
+	default:
+		return errors.Errorf("unknown type %d", col.Tp)
+	}
+	return nil
+}
+
+// BytesDecoder decodes the row to old datums bytes.
+type BytesDecoder struct {
+	decoder
+	defBytes func(i int) ([]byte, error)
+}
+
+// NewByteDecoder creates a BytesDecoder.
+// defBytes: provided default value bytes in old datum format(flag+colData).
+func NewByteDecoder(columns []ColInfo, handleColID int64, defBytes func(i int) ([]byte, error), loc *time.Location) *BytesDecoder {
+	return &BytesDecoder{
+		decoder: decoder{
+			columns:     columns,
+			handleColID: handleColID,
+			loc:         loc,
+		},
+		defBytes: defBytes,
+	}
+}
+
+// DecodeToBytes decodes raw byte slice to row data.
+func (decoder *BytesDecoder) DecodeToBytes(outputOffset map[int64]int, handle int64, value []byte, cacheBytes []byte) ([][]byte, error) {
+	var r row
+	err := r.fromBytes(value)
+	if err != nil {
+		return nil, err
+	}
+	values := make([][]byte, len(outputOffset))
+	for i, col := range decoder.columns {
+		tp := fieldType2Flag(byte(col.Tp), uint(col.Flag)&mysql.UnsignedFlag == 0)
+		colID := col.ID
+		offset := outputOffset[colID]
+		if col.IsPKHandle || colID == model.ExtraHandleID {
+			handleData := cacheBytes
+			if mysql.HasUnsignedFlag(uint(col.Flag)) {
+				handleData = append(handleData, UintFlag)
+				handleData = codec.EncodeUint(handleData, uint64(handle))
+			} else {
+				handleData = append(handleData, IntFlag)
+				handleData = codec.EncodeInt(handleData, handle)
+			}
+			values[offset] = handleData
+			continue
+		}
+
+		idx, isNil, notFound := r.findColID(colID)
+		if !notFound && !isNil {
+			val := r.getData(idx)
+			values[offset] = decoder.encodeOldDatum(tp, val)
+			continue
+		}
+
+		if isNil {
+			values[offset] = []byte{NilFlag}
+			continue
+		}
+
+		if decoder.defBytes != nil {
+			defVal, err := decoder.defBytes(i)
+			if err != nil {
+				return nil, err
+			}
+			if len(defVal) > 0 {
+				values[offset] = defVal
+				continue
+			}
+		}
+
+		values[offset] = []byte{NilFlag}
+	}
+	return values, nil
+}
+
+func (decoder *BytesDecoder) encodeOldDatum(tp byte, val []byte) []byte {
+	var buf []byte
+	switch tp {
+	case BytesFlag:
+		buf = append(buf, CompactBytesFlag)
+		buf = codec.EncodeCompactBytes(buf, val)
+	case IntFlag:
+		buf = append(buf, VarintFlag)
+		buf = codec.EncodeVarint(buf, decodeInt(val))
+	case UintFlag:
+		buf = append(buf, VaruintFlag)
+		buf = codec.EncodeUvarint(buf, decodeUint(val))
+	default:
+		buf = append(buf, tp)
+		buf = append(buf, val...)
+	}
+	return buf
+}
+
+// fieldType2Flag transforms field type into kv type flag.
+func fieldType2Flag(tp byte, signed bool) (flag byte) {
+	switch tp {
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
+		if signed {
+			flag = IntFlag
+		} else {
+			flag = UintFlag
+		}
+	case mysql.TypeFloat, mysql.TypeDouble:
+		flag = FloatFlag
+	case mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob,
+		mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString:
+		flag = BytesFlag
+	case mysql.TypeDatetime, mysql.TypeDate, mysql.TypeTimestamp:
+		flag = UintFlag
+	case mysql.TypeDuration:
+		flag = IntFlag
+	case mysql.TypeNewDecimal:
+		flag = DecimalFlag
+	case mysql.TypeYear:
+		flag = IntFlag
+	case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet:
+		flag = UintFlag
+	case mysql.TypeJSON:
+		flag = JSONFlag
+	case mysql.TypeNull:
+		flag = NilFlag
+	default:
+		panic(fmt.Sprintf("unknown field type %d", tp))
+	}
+	return
+}

--- a/util/rowcodec/encoder.go
+++ b/util/rowcodec/encoder.go
@@ -1,0 +1,231 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/codec"
+)
+
+// Encoder is used to encode a row.
+type Encoder struct {
+	row
+	tempColIDs []int64
+	values     []types.Datum
+}
+
+// Encode encodes a row from a datums slice.
+func (encoder *Encoder) Encode(sc *stmtctx.StatementContext, colIDs []int64, values []types.Datum, buf []byte) ([]byte, error) {
+	encoder.reset()
+	encoder.appendColVals(colIDs, values)
+	numCols, notNullIdx := encoder.reformatCols()
+	err := encoder.encodeRowCols(sc, numCols, notNullIdx)
+	if err != nil {
+		return nil, err
+	}
+	return encoder.row.toBytes(buf[:0]), nil
+}
+
+func (encoder *Encoder) reset() {
+	encoder.large = false
+	encoder.numNotNullCols = 0
+	encoder.numNullCols = 0
+	encoder.data = encoder.data[:0]
+	encoder.tempColIDs = encoder.tempColIDs[:0]
+	encoder.values = encoder.values[:0]
+}
+
+func (encoder *Encoder) appendColVals(colIDs []int64, values []types.Datum) {
+	for i, colID := range colIDs {
+		encoder.appendColVal(colID, values[i])
+	}
+}
+
+func (encoder *Encoder) appendColVal(colID int64, d types.Datum) {
+	if colID > 255 {
+		encoder.large = true
+	}
+	if d.IsNull() {
+		encoder.numNullCols++
+	} else {
+		encoder.numNotNullCols++
+	}
+	encoder.tempColIDs = append(encoder.tempColIDs, colID)
+	encoder.values = append(encoder.values, d)
+}
+
+func (encoder *Encoder) reformatCols() (numCols, notNullIdx int) {
+	r := &encoder.row
+	numCols = len(encoder.tempColIDs)
+	nullIdx := numCols - int(r.numNullCols)
+	notNullIdx = 0
+	if r.large {
+		r.initColIDs32()
+		r.initOffsets32()
+	} else {
+		r.initColIDs()
+		r.initOffsets()
+	}
+	for i, colID := range encoder.tempColIDs {
+		if encoder.values[i].IsNull() {
+			if r.large {
+				r.colIDs32[nullIdx] = uint32(colID)
+			} else {
+				r.colIDs[nullIdx] = byte(colID)
+			}
+			nullIdx++
+		} else {
+			if r.large {
+				r.colIDs32[notNullIdx] = uint32(colID)
+			} else {
+				r.colIDs[notNullIdx] = byte(colID)
+			}
+			encoder.values[notNullIdx] = encoder.values[i]
+			notNullIdx++
+		}
+	}
+	if r.large {
+		largeNotNullSorter := (*largeNotNullSorter)(encoder)
+		sort.Sort(largeNotNullSorter)
+		if r.numNullCols > 0 {
+			largeNullSorter := (*largeNullSorter)(encoder)
+			sort.Sort(largeNullSorter)
+		}
+	} else {
+		smallNotNullSorter := (*smallNotNullSorter)(encoder)
+		sort.Sort(smallNotNullSorter)
+		if r.numNullCols > 0 {
+			smallNullSorter := (*smallNullSorter)(encoder)
+			sort.Sort(smallNullSorter)
+		}
+	}
+	return
+}
+
+func (encoder *Encoder) encodeRowCols(sc *stmtctx.StatementContext, numCols, notNullIdx int) error {
+	r := &encoder.row
+	for i := 0; i < notNullIdx; i++ {
+		d := encoder.values[i]
+		var err error
+		r.data, err = EncodeValueDatum(sc, d, r.data)
+		if err != nil {
+			return err
+		}
+		// handle convert to large
+		if len(r.data) > math.MaxUint16 && !r.large {
+			r.initColIDs32()
+			for j := 0; j < numCols; j++ {
+				r.colIDs32[j] = uint32(r.colIDs[j])
+			}
+			r.initOffsets32()
+			for j := 0; j <= i; j++ {
+				r.offsets32[j] = uint32(r.offsets[j])
+			}
+			r.large = true
+		}
+		if r.large {
+			r.offsets32[i] = uint32(len(r.data))
+		} else {
+			r.offsets[i] = uint16(len(r.data))
+		}
+	}
+	// handle convert to large
+	if !r.large {
+		if len(r.data) >= math.MaxUint16 {
+			r.large = true
+			r.initColIDs32()
+			for i, val := range r.colIDs {
+				r.colIDs32[i] = uint32(val)
+			}
+		} else {
+			r.initOffsets()
+			for i, val := range r.offsets32 {
+				r.offsets[i] = uint16(val)
+			}
+		}
+	}
+	return nil
+}
+
+// EncodeValueDatum encodes one row datum entry into bytes.
+// due to encode as value, this method will flatten value type like tablecodec.flatten
+func EncodeValueDatum(sc *stmtctx.StatementContext, d types.Datum, buffer []byte) (nBuffer []byte, err error) {
+	switch d.Kind() {
+	case types.KindInt64:
+		buffer = encodeInt(buffer, d.GetInt64())
+	case types.KindUint64:
+		buffer = encodeUint(buffer, d.GetUint64())
+	case types.KindString, types.KindBytes:
+		buffer = append(buffer, d.GetBytes()...)
+	case types.KindMysqlTime:
+		// for mysql datetime, timestamp and date type
+		t := d.GetMysqlTime()
+		if t.Type == mysql.TypeTimestamp && sc != nil && sc.TimeZone != time.UTC {
+			err = t.ConvertTimeZone(sc.TimeZone, time.UTC)
+			if err != nil {
+				return
+			}
+		}
+		var v uint64
+		v, err = t.ToPackedUint()
+		if err != nil {
+			return
+		}
+		buffer = encodeUint(buffer, v)
+	case types.KindMysqlDuration:
+		buffer = encodeInt(buffer, int64(d.GetMysqlDuration().Duration))
+	case types.KindMysqlEnum:
+		buffer = encodeUint(buffer, d.GetMysqlEnum().Value)
+	case types.KindMysqlSet:
+		buffer = encodeUint(buffer, d.GetMysqlSet().Value)
+	case types.KindBinaryLiteral, types.KindMysqlBit:
+		// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
+		var val uint64
+		val, err = d.GetBinaryLiteral().ToInt(sc)
+		if err != nil {
+			return
+		}
+		buffer = encodeUint(buffer, val)
+	case types.KindFloat32, types.KindFloat64:
+		buffer = codec.EncodeFloat(buffer, d.GetFloat64())
+	case types.KindMysqlDecimal:
+		buffer, err = codec.EncodeDecimal(buffer, d.GetMysqlDecimal(), d.Length(), d.Frac())
+		if sc != nil {
+			if terror.ErrorEqual(err, types.ErrTruncated) {
+				err = sc.HandleTruncate(err)
+			} else if terror.ErrorEqual(err, types.ErrOverflow) {
+				err = sc.HandleOverflow(err, err)
+			}
+		}
+	case types.KindMysqlJSON:
+		j := d.GetMysqlJSON()
+		buffer = append(buffer, j.TypeCode)
+		buffer = append(buffer, j.Value...)
+	case types.KindNull:
+	case types.KindMinNotNull:
+	case types.KindMaxValue:
+	default:
+		err = errors.Errorf("unsupport encode type %d", d.Kind())
+	}
+	nBuffer = buffer
+	return
+}

--- a/util/rowcodec/export_test.go
+++ b/util/rowcodec/export_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec
+
+import (
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/codec"
+)
+
+// EncodeFromOldRow encodes a row from an old-format row.
+// this method will be used in test.
+func EncodeFromOldRow(encoder *Encoder, sc *stmtctx.StatementContext, oldRow, buf []byte) ([]byte, error) {
+	if len(oldRow) > 0 && oldRow[0] == CodecVer {
+		return oldRow, nil
+	}
+	encoder.reset()
+	for len(oldRow) > 1 {
+		var d types.Datum
+		var err error
+		oldRow, d, err = codec.DecodeOne(oldRow)
+		if err != nil {
+			return nil, err
+		}
+		colID := d.GetInt64()
+		oldRow, d, err = codec.DecodeOne(oldRow)
+		if err != nil {
+			return nil, err
+		}
+		encoder.appendColVal(colID, d)
+	}
+	numCols, notNullIdx := encoder.reformatCols()
+	err := encoder.encodeRowCols(sc, numCols, notNullIdx)
+	if err != nil {
+		return nil, err
+	}
+	return encoder.row.toBytes(buf[:0]), nil
+}

--- a/util/rowcodec/row.go
+++ b/util/rowcodec/row.go
@@ -1,0 +1,192 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec
+
+import (
+	"encoding/binary"
+)
+
+// row is the struct type used to access the a row.
+type row struct {
+	// small:  colID []byte, offsets []uint16, optimized for most cases.
+	// large:  colID []uint32, offsets []uint32.
+	large          bool
+	numNotNullCols uint16
+	numNullCols    uint16
+	colIDs         []byte
+
+	offsets []uint16
+	data    []byte
+
+	// for large row
+	colIDs32  []uint32
+	offsets32 []uint32
+}
+
+func (r *row) getData(i int) []byte {
+	var start, end uint32
+	if r.large {
+		if i > 0 {
+			start = r.offsets32[i-1]
+		}
+		end = r.offsets32[i]
+	} else {
+		if i > 0 {
+			start = uint32(r.offsets[i-1])
+		}
+		end = uint32(r.offsets[i])
+	}
+	return r.data[start:end]
+}
+
+func (r *row) fromBytes(rowData []byte) error {
+	if rowData[0] != CodecVer {
+		return errInvalidCodecVer
+	}
+	r.large = rowData[1]&1 > 0
+	r.numNotNullCols = binary.LittleEndian.Uint16(rowData[2:])
+	r.numNullCols = binary.LittleEndian.Uint16(rowData[4:])
+	cursor := 6
+	if r.large {
+		colIDsLen := int(r.numNotNullCols+r.numNullCols) * 4
+		r.colIDs32 = bytesToU32Slice(rowData[cursor : cursor+colIDsLen])
+		cursor += colIDsLen
+		offsetsLen := int(r.numNotNullCols) * 4
+		r.offsets32 = bytesToU32Slice(rowData[cursor : cursor+offsetsLen])
+		cursor += offsetsLen
+	} else {
+		colIDsLen := int(r.numNotNullCols + r.numNullCols)
+		r.colIDs = rowData[cursor : cursor+colIDsLen]
+		cursor += colIDsLen
+		offsetsLen := int(r.numNotNullCols) * 2
+		r.offsets = bytes2U16Slice(rowData[cursor : cursor+offsetsLen])
+		cursor += offsetsLen
+	}
+	r.data = rowData[cursor:]
+	return nil
+}
+
+func (r *row) toBytes(buf []byte) []byte {
+	buf = append(buf, CodecVer)
+	flag := byte(0)
+	if r.large {
+		flag = 1
+	}
+	buf = append(buf, flag)
+	buf = append(buf, byte(r.numNotNullCols), byte(r.numNotNullCols>>8))
+	buf = append(buf, byte(r.numNullCols), byte(r.numNullCols>>8))
+	if r.large {
+		buf = append(buf, u32SliceToBytes(r.colIDs32)...)
+		buf = append(buf, u32SliceToBytes(r.offsets32)...)
+	} else {
+		buf = append(buf, r.colIDs...)
+		buf = append(buf, u16SliceToBytes(r.offsets)...)
+	}
+	buf = append(buf, r.data...)
+	return buf
+}
+
+func (r *row) findColID(colID int64) (idx int, isNil, notFound bool) {
+	// Search the column in not-null columns array.
+	i, j := 0, int(r.numNotNullCols)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		var v int64
+		if r.large {
+			v = int64(r.colIDs32[h])
+		} else {
+			v = int64(r.colIDs[h])
+		}
+		if v < colID {
+			i = h + 1
+		} else if v > colID {
+			j = h
+		} else {
+			idx = h
+			return
+		}
+	}
+
+	// Search the column in null columns array.
+	i, j = int(r.numNotNullCols), int(r.numNotNullCols+r.numNullCols)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		var v int64
+		if r.large {
+			v = int64(r.colIDs32[h])
+		} else {
+			v = int64(r.colIDs[h])
+		}
+		if v < colID {
+			i = h + 1
+		} else if v > colID {
+			j = h
+		} else {
+			isNil = true
+			return
+		}
+	}
+	notFound = true
+	return
+}
+
+// ColumnIsNull returns if the column value is null. Mainly used for count column aggregation.
+// this method will used in unistore.
+func (r *row) ColumnIsNull(rowData []byte, colID int64, defaultVal []byte) (bool, error) {
+	err := r.fromBytes(rowData)
+	if err != nil {
+		return false, err
+	}
+	_, isNil, notFound := r.findColID(colID)
+	if notFound {
+		return defaultVal == nil, nil
+	}
+	return isNil, nil
+}
+
+func (r *row) initColIDs() {
+	numCols := int(r.numNotNullCols + r.numNullCols)
+	if cap(r.colIDs) >= numCols {
+		r.colIDs = r.colIDs[:numCols]
+	} else {
+		r.colIDs = make([]byte, numCols)
+	}
+}
+
+func (r *row) initColIDs32() {
+	numCols := int(r.numNotNullCols + r.numNullCols)
+	if cap(r.colIDs32) >= numCols {
+		r.colIDs32 = r.colIDs32[:numCols]
+	} else {
+		r.colIDs32 = make([]uint32, numCols)
+	}
+}
+
+func (r *row) initOffsets() {
+	if cap(r.offsets) >= int(r.numNotNullCols) {
+		r.offsets = r.offsets[:r.numNotNullCols]
+	} else {
+		r.offsets = make([]uint16, r.numNotNullCols)
+	}
+}
+
+func (r *row) initOffsets32() {
+	if cap(r.offsets32) >= int(r.numNotNullCols) {
+		r.offsets32 = r.offsets32[:r.numNotNullCols]
+	} else {
+		r.offsets32 = make([]uint32, r.numNotNullCols)
+	}
+}

--- a/util/rowcodec/rowcodec_test.go
+++ b/util/rowcodec/rowcodec_test.go
@@ -1,0 +1,732 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rowcodec_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/rowcodec"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testSuite{})
+
+type testSuite struct{}
+
+type testData struct {
+	id     int64
+	ft     *types.FieldType
+	dt     types.Datum
+	bt     types.Datum
+	def    *types.Datum
+	handle bool
+}
+
+func (s *testSuite) TestDecodeRowWithHandle(c *C) {
+	handleID := int64(-1)
+	handleValue := int64(10000)
+
+	encodeAndDecodeHandle := func(c *C, testData []testData) {
+		// transform test data into input.
+		colIDs := make([]int64, 0, len(testData))
+		dts := make([]types.Datum, 0, len(testData))
+		fts := make([]*types.FieldType, 0, len(testData))
+		cols := make([]rowcodec.ColInfo, 0, len(testData))
+		for i := range testData {
+			t := testData[i]
+			if !t.handle {
+				colIDs = append(colIDs, t.id)
+				dts = append(dts, t.dt)
+			}
+			fts = append(fts, t.ft)
+			cols = append(cols, rowcodec.ColInfo{
+				ID:         t.id,
+				Tp:         int32(t.ft.Tp),
+				Flag:       int32(t.ft.Flag),
+				IsPKHandle: t.handle,
+				Flen:       t.ft.Flen,
+				Decimal:    t.ft.Decimal,
+				Elems:      t.ft.Elems,
+			})
+		}
+
+		// test encode input.
+		var encoder rowcodec.Encoder
+		sc := new(stmtctx.StatementContext)
+		sc.TimeZone = time.UTC
+		newRow, err := encoder.Encode(sc, colIDs, dts, nil)
+		c.Assert(err, IsNil)
+
+		// decode to datum map.
+		mDecoder := rowcodec.NewDatumMapDecoder(cols, -1, sc.TimeZone)
+		dm, err := mDecoder.DecodeToDatumMap(newRow, handleValue, nil)
+		c.Assert(err, IsNil)
+		for _, t := range testData {
+			d, exists := dm[t.id]
+			c.Assert(exists, IsTrue)
+			c.Assert(d, DeepEquals, t.dt)
+		}
+
+		// decode to chunk.
+		cDecoder := rowcodec.NewChunkDecoder(cols, -1, nil, sc.TimeZone)
+		chk := chunk.New(fts, 1, 1)
+		err = cDecoder.DecodeToChunk(newRow, handleValue, chk)
+		c.Assert(err, IsNil)
+		chkRow := chk.GetRow(0)
+		cdt := chkRow.GetDatumRow(fts)
+		for i, t := range testData {
+			d := cdt[i]
+			if d.Kind() == types.KindMysqlDecimal {
+				c.Assert(d.GetMysqlDecimal(), DeepEquals, t.bt.GetMysqlDecimal())
+			} else {
+				c.Assert(d, DeepEquals, t.bt)
+			}
+		}
+
+		// decode to old row bytes.
+		colOffset := make(map[int64]int)
+		for i, t := range testData {
+			colOffset[t.id] = i
+		}
+		bDecoder := rowcodec.NewByteDecoder(cols, -1, nil, nil)
+		oldRow, err := bDecoder.DecodeToBytes(colOffset, handleValue, newRow, nil)
+		c.Assert(err, IsNil)
+		for i, t := range testData {
+			remain, d, err := codec.DecodeOne(oldRow[i])
+			c.Assert(err, IsNil)
+			c.Assert(len(remain), Equals, 0)
+			if d.Kind() == types.KindMysqlDecimal {
+				c.Assert(d.GetMysqlDecimal(), DeepEquals, t.bt.GetMysqlDecimal())
+			} else {
+				c.Assert(d, DeepEquals, t.bt)
+			}
+		}
+	}
+
+	// encode & decode signed int.
+	testDataSigned := []testData{
+		{
+			handleID,
+			types.NewFieldType(mysql.TypeLonglong),
+			types.NewIntDatum(handleValue),
+			types.NewIntDatum(handleValue),
+			nil,
+			true,
+		},
+		{
+			10,
+			types.NewFieldType(mysql.TypeLonglong),
+			types.NewIntDatum(1),
+			types.NewIntDatum(1),
+			nil,
+			false,
+		},
+	}
+	encodeAndDecodeHandle(c, testDataSigned)
+
+	// encode & decode unsigned int.
+	testDataUnsigned := []testData{
+		{
+			handleID,
+			withUnsigned(types.NewFieldType(mysql.TypeLonglong)),
+			types.NewIntDatum(handleValue),          // decode as chunk & map, always encode it as int
+			types.NewUintDatum(uint64(handleValue)), // decode as bytes will uint if unsigned.
+			nil,
+			true,
+		},
+		{
+			10,
+			types.NewFieldType(mysql.TypeLonglong),
+			types.NewIntDatum(1),
+			types.NewIntDatum(1),
+			nil,
+			false,
+		},
+	}
+	encodeAndDecodeHandle(c, testDataUnsigned)
+}
+
+func (s *testSuite) TestTypesNewRowCodec(c *C) {
+	getJSONDatum := func(value string) types.Datum {
+		j, err := json.ParseBinaryFromString(value)
+		c.Assert(err, IsNil)
+		var d types.Datum
+		d.SetMysqlJSON(j)
+		return d
+	}
+	getSetDatum := func(name string, value uint64) types.Datum {
+		var d types.Datum
+		d.SetMysqlSet(types.Set{Name: name, Value: value})
+		return d
+	}
+	getTime := func(value string) types.Time {
+		t, err := types.ParseTime(&stmtctx.StatementContext{TimeZone: time.UTC}, value, mysql.TypeTimestamp, 6)
+		c.Assert(err, IsNil)
+		return t
+	}
+
+	encodeAndDecode := func(c *C, testData []testData) {
+		// transform test data into input.
+		colIDs := make([]int64, 0, len(testData))
+		dts := make([]types.Datum, 0, len(testData))
+		fts := make([]*types.FieldType, 0, len(testData))
+		cols := make([]rowcodec.ColInfo, 0, len(testData))
+		for i := range testData {
+			t := testData[i]
+			colIDs = append(colIDs, t.id)
+			dts = append(dts, t.dt)
+			fts = append(fts, t.ft)
+			cols = append(cols, rowcodec.ColInfo{
+				ID:         t.id,
+				Tp:         int32(t.ft.Tp),
+				Flag:       int32(t.ft.Flag),
+				IsPKHandle: t.handle,
+				Flen:       t.ft.Flen,
+				Decimal:    t.ft.Decimal,
+				Elems:      t.ft.Elems,
+			})
+		}
+
+		// test encode input.
+		var encoder rowcodec.Encoder
+		sc := new(stmtctx.StatementContext)
+		sc.TimeZone = time.UTC
+		newRow, err := encoder.Encode(sc, colIDs, dts, nil)
+		c.Assert(err, IsNil)
+
+		// decode to datum map.
+		mDecoder := rowcodec.NewDatumMapDecoder(cols, -1, sc.TimeZone)
+		dm, err := mDecoder.DecodeToDatumMap(newRow, -1, nil)
+		c.Assert(err, IsNil)
+		for _, t := range testData {
+			d, exists := dm[t.id]
+			c.Assert(exists, IsTrue)
+			c.Assert(d, DeepEquals, t.dt)
+		}
+
+		// decode to chunk.
+		cDecoder := rowcodec.NewChunkDecoder(cols, -1, nil, sc.TimeZone)
+		chk := chunk.New(fts, 1, 1)
+		err = cDecoder.DecodeToChunk(newRow, -1, chk)
+		c.Assert(err, IsNil)
+		chkRow := chk.GetRow(0)
+		cdt := chkRow.GetDatumRow(fts)
+		for i, t := range testData {
+			d := cdt[i]
+			if d.Kind() == types.KindMysqlDecimal {
+				c.Assert(d.GetMysqlDecimal(), DeepEquals, t.bt.GetMysqlDecimal())
+			} else {
+				c.Assert(d, DeepEquals, t.dt)
+			}
+		}
+
+		// decode to old row bytes.
+		colOffset := make(map[int64]int)
+		for i, t := range testData {
+			colOffset[t.id] = i
+		}
+		bDecoder := rowcodec.NewByteDecoder(cols, -1, nil, nil)
+		oldRow, err := bDecoder.DecodeToBytes(colOffset, -1, newRow, nil)
+		c.Assert(err, IsNil)
+		for i, t := range testData {
+			remain, d, err := codec.DecodeOne(oldRow[i])
+			c.Assert(err, IsNil)
+			c.Assert(len(remain), Equals, 0)
+			if d.Kind() == types.KindMysqlDecimal {
+				c.Assert(d.GetMysqlDecimal(), DeepEquals, t.bt.GetMysqlDecimal())
+			} else {
+				c.Assert(d, DeepEquals, t.bt)
+			}
+		}
+	}
+
+	testData := []testData{
+		{
+			1,
+			types.NewFieldType(mysql.TypeLonglong),
+			types.NewIntDatum(1),
+			types.NewIntDatum(1),
+			nil,
+			false,
+		},
+		{
+			22,
+			withUnsigned(types.NewFieldType(mysql.TypeShort)),
+			types.NewUintDatum(1),
+			types.NewUintDatum(1),
+			nil,
+			false,
+		},
+		{
+			3,
+			types.NewFieldType(mysql.TypeDouble),
+			types.NewFloat64Datum(2),
+			types.NewFloat64Datum(2),
+			nil,
+			false,
+		},
+		{
+			24,
+			types.NewFieldType(mysql.TypeString),
+			types.NewBytesDatum([]byte("abc")),
+			types.NewBytesDatum([]byte("abc")),
+			nil,
+			false,
+		},
+		{
+			5,
+			withFsp(6)(types.NewFieldType(mysql.TypeTimestamp)),
+			types.NewTimeDatum(getTime("2011-11-10 11:11:11.999999")),
+			types.NewUintDatum(1840446893366133311),
+			nil,
+			false,
+		},
+		{
+			16,
+			withFsp(0)(types.NewFieldType(mysql.TypeDuration)),
+			types.NewDurationDatum(getDuration("4:00:00")),
+			types.NewIntDatum(14400000000000),
+			nil,
+			false,
+		},
+		{
+			8,
+			types.NewFieldType(mysql.TypeNewDecimal),
+			types.NewDecimalDatum(types.NewDecFromStringForTest("1.99")),
+			types.NewDecimalDatum(types.NewDecFromStringForTest("1.99")),
+			nil,
+			false,
+		},
+		{
+			12,
+			types.NewFieldType(mysql.TypeYear),
+			types.NewIntDatum(1999),
+			types.NewIntDatum(1999),
+			nil,
+			false,
+		},
+		{
+			9,
+			withEnumElems("y", "n")(types.NewFieldType(mysql.TypeEnum)),
+			types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
+			types.NewUintDatum(2),
+			nil,
+			false,
+		},
+		{
+			14,
+			types.NewFieldType(mysql.TypeJSON),
+			getJSONDatum(`{"a":2}`),
+			getJSONDatum(`{"a":2}`),
+			nil,
+			false,
+		},
+		{
+			11,
+			types.NewFieldType(mysql.TypeNull),
+			types.NewDatum(nil),
+			types.NewDatum(nil),
+			nil,
+			false,
+		},
+		{
+			2,
+			types.NewFieldType(mysql.TypeNull),
+			types.NewDatum(nil),
+			types.NewDatum(nil),
+			nil,
+			false,
+		},
+		{
+			100,
+			types.NewFieldType(mysql.TypeNull),
+			types.NewDatum(nil),
+			types.NewDatum(nil),
+			nil,
+			false,
+		},
+		{
+			116,
+			types.NewFieldType(mysql.TypeFloat),
+			types.NewFloat32Datum(6),
+			types.NewFloat64Datum(6),
+			nil,
+			false,
+		},
+		{
+			117,
+			withEnumElems("n1", "n2")(types.NewFieldType(mysql.TypeSet)),
+			getSetDatum("n1", 1),
+			types.NewUintDatum(1),
+			nil,
+			false,
+		},
+		{
+			118,
+			withFlen(24)(types.NewFieldType(mysql.TypeBit)), // 3 bit
+			types.NewMysqlBitDatum(types.NewBinaryLiteralFromUint(3223600, 3)),
+			types.NewUintDatum(3223600),
+			nil,
+			false,
+		},
+		{
+			119,
+			types.NewFieldType(mysql.TypeVarString),
+			types.NewBytesDatum([]byte("")),
+			types.NewBytesDatum([]byte("")),
+			nil,
+			false,
+		},
+	}
+
+	// test small
+	encodeAndDecode(c, testData)
+
+	// test large colID
+	testData[0].id = 300
+	encodeAndDecode(c, testData)
+	testData[0].id = 1
+
+	// test large data
+	testData[3].dt = types.NewBytesDatum([]byte(strings.Repeat("a", math.MaxUint16+1)))
+	testData[3].bt = types.NewBytesDatum([]byte(strings.Repeat("a", math.MaxUint16+1)))
+	encodeAndDecode(c, testData)
+}
+
+func (s *testSuite) TestNilAndDefault(c *C) {
+	encodeAndDecode := func(c *C, testData []testData) {
+		// transform test data into input.
+		colIDs := make([]int64, 0, len(testData))
+		dts := make([]types.Datum, 0, len(testData))
+		cols := make([]rowcodec.ColInfo, 0, len(testData))
+		fts := make([]*types.FieldType, 0, len(testData))
+		for i := range testData {
+			t := testData[i]
+			if t.def == nil {
+				colIDs = append(colIDs, t.id)
+				dts = append(dts, t.dt)
+			}
+			fts = append(fts, t.ft)
+			cols = append(cols, rowcodec.ColInfo{
+				ID:         t.id,
+				Tp:         int32(t.ft.Tp),
+				Flag:       int32(t.ft.Flag),
+				IsPKHandle: t.handle,
+				Flen:       t.ft.Flen,
+				Decimal:    t.ft.Decimal,
+				Elems:      t.ft.Elems,
+			})
+		}
+		ddf := func(i int) (types.Datum, error) {
+			t := testData[i]
+			if t.def == nil {
+				var d types.Datum
+				d.SetNull()
+				return d, nil
+			}
+			return *t.def, nil
+		}
+		bdf := func(i int) ([]byte, error) {
+			t := testData[i]
+			if t.def == nil {
+				return nil, nil
+			}
+			return getOldDatumByte(*t.def), nil
+		}
+		// test encode input.
+		var encoder rowcodec.Encoder
+		sc := new(stmtctx.StatementContext)
+		sc.TimeZone = time.UTC
+		newRow, err := encoder.Encode(sc, colIDs, dts, nil)
+		c.Assert(err, IsNil)
+
+		// decode to datum map.
+		mDecoder := rowcodec.NewDatumMapDecoder(cols, -1, sc.TimeZone)
+		dm, err := mDecoder.DecodeToDatumMap(newRow, -1, nil)
+		c.Assert(err, IsNil)
+		for _, t := range testData {
+			d, exists := dm[t.id]
+			if t.def != nil {
+				// for datum should not fill default value.
+				c.Assert(exists, IsFalse)
+			} else {
+				c.Assert(exists, IsTrue)
+				c.Assert(d, DeepEquals, t.bt)
+			}
+		}
+
+		//decode to chunk.
+		chk := chunk.New(fts, 1, 1)
+		cDecoder := rowcodec.NewChunkDecoder(cols, -1, ddf, sc.TimeZone)
+		err = cDecoder.DecodeToChunk(newRow, -1, chk)
+		c.Assert(err, IsNil)
+		chkRow := chk.GetRow(0)
+		cdt := chkRow.GetDatumRow(fts)
+		for i, t := range testData {
+			d := cdt[i]
+			if d.Kind() == types.KindMysqlDecimal {
+				c.Assert(d.GetMysqlDecimal(), DeepEquals, t.bt.GetMysqlDecimal())
+			} else {
+				c.Assert(d, DeepEquals, t.bt)
+			}
+		}
+
+		// decode to old row bytes.
+		colOffset := make(map[int64]int)
+		for i, t := range testData {
+			colOffset[t.id] = i
+		}
+		bDecoder := rowcodec.NewByteDecoder(cols, -1, bdf, sc.TimeZone)
+		oldRow, err := bDecoder.DecodeToBytes(colOffset, -1, newRow, nil)
+		c.Assert(err, IsNil)
+		for i, t := range testData {
+			remain, d, err := codec.DecodeOne(oldRow[i])
+			c.Assert(err, IsNil)
+			c.Assert(len(remain), Equals, 0)
+			if d.Kind() == types.KindMysqlDecimal {
+				c.Assert(d.GetMysqlDecimal(), DeepEquals, t.bt.GetMysqlDecimal())
+			} else {
+				c.Assert(d, DeepEquals, t.bt)
+			}
+		}
+	}
+	dtNilData := []testData{
+		{
+			1,
+			types.NewFieldType(mysql.TypeLonglong),
+			types.NewIntDatum(1),
+			types.NewIntDatum(1),
+			nil,
+			false,
+		},
+		{
+			2,
+			withUnsigned(types.NewFieldType(mysql.TypeLonglong)),
+			types.NewUintDatum(1),
+			types.NewUintDatum(9),
+			getDatumPoint(types.NewUintDatum(9)),
+			false,
+		},
+	}
+	encodeAndDecode(c, dtNilData)
+}
+
+func (s *testSuite) TestVarintCompatibility(c *C) {
+	encodeAndDecodeByte := func(c *C, testData []testData) {
+		// transform test data into input.
+		colIDs := make([]int64, 0, len(testData))
+		dts := make([]types.Datum, 0, len(testData))
+		fts := make([]*types.FieldType, 0, len(testData))
+		cols := make([]rowcodec.ColInfo, 0, len(testData))
+		for i := range testData {
+			t := testData[i]
+			colIDs = append(colIDs, t.id)
+			dts = append(dts, t.dt)
+			fts = append(fts, t.ft)
+			cols = append(cols, rowcodec.ColInfo{
+				ID:         t.id,
+				Tp:         int32(t.ft.Tp),
+				Flag:       int32(t.ft.Flag),
+				IsPKHandle: t.handle,
+				Flen:       t.ft.Flen,
+				Decimal:    t.ft.Decimal,
+				Elems:      t.ft.Elems,
+			})
+		}
+
+		// test encode input.
+		var encoder rowcodec.Encoder
+		sc := new(stmtctx.StatementContext)
+		sc.TimeZone = time.UTC
+		newRow, err := encoder.Encode(sc, colIDs, dts, nil)
+		c.Assert(err, IsNil)
+		decoder := rowcodec.NewByteDecoder(cols, -1, nil, sc.TimeZone)
+		// decode to old row bytes.
+		colOffset := make(map[int64]int)
+		for i, t := range testData {
+			colOffset[t.id] = i
+		}
+		oldRow, err := decoder.DecodeToBytes(colOffset, 1, newRow, nil)
+		c.Assert(err, IsNil)
+		for i, t := range testData {
+			oldVarint, err := tablecodec.EncodeValue(nil, nil, t.bt) // tablecodec will encode as varint/varuint
+			c.Assert(err, IsNil)
+			c.Assert(oldVarint, DeepEquals, oldRow[i])
+		}
+	}
+
+	testDataValue := []testData{
+		{
+			1,
+			types.NewFieldType(mysql.TypeLonglong),
+			types.NewIntDatum(1),
+			types.NewIntDatum(1),
+			nil,
+			false,
+		},
+		{
+			2,
+			withUnsigned(types.NewFieldType(mysql.TypeLonglong)),
+			types.NewUintDatum(1),
+			types.NewUintDatum(1),
+			nil,
+			false,
+		},
+	}
+	encodeAndDecodeByte(c, testDataValue)
+}
+
+func (s *testSuite) TestCodecUtil(c *C) {
+	colIDs := []int64{1, 2, 3, 4}
+	tps := make([]*types.FieldType, 4)
+	for i := 0; i < 3; i++ {
+		tps[i] = types.NewFieldType(mysql.TypeLonglong)
+	}
+	tps[3] = types.NewFieldType(mysql.TypeNull)
+	sc := new(stmtctx.StatementContext)
+	oldRow, err := tablecodec.EncodeRow(sc, types.MakeDatums(1, 2, 3, nil), colIDs, nil, nil)
+	c.Check(err, IsNil)
+	var (
+		rb     rowcodec.Encoder
+		newRow []byte
+	)
+	newRow, err = rowcodec.EncodeFromOldRow(&rb, nil, oldRow, nil)
+	c.Assert(err, IsNil)
+	c.Assert(rowcodec.IsNewFormat(newRow), IsTrue)
+	c.Assert(rowcodec.IsNewFormat(oldRow), IsFalse)
+
+	// test stringer for decoder.
+	var cols []rowcodec.ColInfo
+	for i, ft := range tps {
+		cols = append(cols, rowcodec.ColInfo{
+			ID:         colIDs[i],
+			Tp:         int32(ft.Tp),
+			Flag:       int32(ft.Flag),
+			IsPKHandle: false,
+			Flen:       ft.Flen,
+			Decimal:    ft.Decimal,
+			Elems:      ft.Elems,
+		})
+	}
+	d := rowcodec.NewDecoder(cols, -1, nil)
+
+	// test ColumnIsNull
+	isNil, err := d.ColumnIsNull(newRow, 4, nil)
+	c.Assert(err, IsNil)
+	c.Assert(isNil, IsTrue)
+	isNil, err = d.ColumnIsNull(newRow, 1, nil)
+	c.Assert(err, IsNil)
+	c.Assert(isNil, IsFalse)
+	isNil, err = d.ColumnIsNull(newRow, 5, nil)
+	c.Assert(err, IsNil)
+	c.Assert(isNil, IsTrue)
+	isNil, err = d.ColumnIsNull(newRow, 5, []byte{1})
+	c.Assert(err, IsNil)
+	c.Assert(isNil, IsFalse)
+
+	// test isRowKey
+	c.Assert(rowcodec.IsRowKey([]byte{'b', 't'}), IsFalse)
+	c.Assert(rowcodec.IsRowKey([]byte{'t', 'r'}), IsFalse)
+}
+
+func (s *testSuite) TestOldRowCodec(c *C) {
+	colIDs := []int64{1, 2, 3, 4}
+	tps := make([]*types.FieldType, 4)
+	for i := 0; i < 3; i++ {
+		tps[i] = types.NewFieldType(mysql.TypeLonglong)
+	}
+	tps[3] = types.NewFieldType(mysql.TypeNull)
+	sc := new(stmtctx.StatementContext)
+	oldRow, err := tablecodec.EncodeRow(sc, types.MakeDatums(1, 2, 3, nil), colIDs, nil, nil)
+	c.Check(err, IsNil)
+
+	var (
+		rb     rowcodec.Encoder
+		newRow []byte
+	)
+	newRow, err = rowcodec.EncodeFromOldRow(&rb, nil, oldRow, nil)
+	c.Check(err, IsNil)
+	cols := make([]rowcodec.ColInfo, len(tps))
+	for i, tp := range tps {
+		cols[i] = rowcodec.ColInfo{
+			ID:      colIDs[i],
+			Tp:      int32(tp.Tp),
+			Flag:    int32(tp.Flag),
+			Flen:    tp.Flen,
+			Decimal: tp.Decimal,
+			Elems:   tp.Elems,
+		}
+	}
+	rd := rowcodec.NewChunkDecoder(cols, 0, nil, time.Local)
+	chk := chunk.NewChunkWithCapacity(tps, 1)
+	err = rd.DecodeToChunk(newRow, -1, chk)
+	c.Assert(err, IsNil)
+	row := chk.GetRow(0)
+	for i := 0; i < 3; i++ {
+		c.Assert(row.GetInt64(i), Equals, int64(i)+1)
+	}
+}
+
+var (
+	withUnsigned = func(ft *types.FieldType) *types.FieldType {
+		ft.Flag = ft.Flag | mysql.UnsignedFlag
+		return ft
+	}
+	withEnumElems = func(elem ...string) func(ft *types.FieldType) *types.FieldType {
+		return func(ft *types.FieldType) *types.FieldType {
+			ft.Elems = elem
+			return ft
+		}
+	}
+	withFsp = func(fsp int) func(ft *types.FieldType) *types.FieldType {
+		return func(ft *types.FieldType) *types.FieldType {
+			ft.Decimal = fsp
+			return ft
+		}
+	}
+	withFlen = func(flen int) func(ft *types.FieldType) *types.FieldType {
+		return func(ft *types.FieldType) *types.FieldType {
+			ft.Flen = flen
+			return ft
+		}
+	}
+	getDuration = func(value string) types.Duration {
+		dur, _ := types.ParseDuration(nil, value, 0)
+		return dur
+	}
+	getOldDatumByte = func(d types.Datum) []byte {
+		b, err := tablecodec.EncodeValue(nil, nil, d)
+		if err != nil {
+			panic(err)
+		}
+		return b
+	}
+	getDatumPoint = func(d types.Datum) *types.Datum {
+		return &d
+	}
+)

--- a/util/rowcodec/rowcodec_test.go
+++ b/util/rowcodec/rowcodec_test.go
@@ -520,7 +520,6 @@ func (s *testSuite) TestCodecUtil(c *C) {
 	newRow, err = rowcodec.EncodeFromOldRow(&rb, nil, oldRow, nil)
 	c.Assert(err, IsNil)
 	c.Assert(rowcodec.IsNewFormat(newRow), IsTrue)
-	c.Assert(rowcodec.IsNewFormat(oldRow), IsFalse)
 
 	// test stringer for decoder.
 	var cols []rowcodec.ColInfo
@@ -560,24 +559,6 @@ var (
 	withUnsigned = func(ft *types.FieldType) *types.FieldType {
 		ft.Flag = ft.Flag | mysql.UnsignedFlag
 		return ft
-	}
-	withEnumElems = func(elem ...string) func(ft *types.FieldType) *types.FieldType {
-		return func(ft *types.FieldType) *types.FieldType {
-			ft.Elems = elem
-			return ft
-		}
-	}
-	withFsp = func(fsp int) func(ft *types.FieldType) *types.FieldType {
-		return func(ft *types.FieldType) *types.FieldType {
-			ft.Decimal = fsp
-			return ft
-		}
-	}
-	withFlen = func(flen int) func(ft *types.FieldType) *types.FieldType {
-		return func(ft *types.FieldType) *types.FieldType {
-			ft.Flen = flen
-			return ft
-		}
 	}
 	getOldDatumByte = func(d types.Datum) []byte {
 		b, err := tablecodec.EncodeValue(nil, nil, d)


### PR DESCRIPTION
TinyKV is using new row format to deocde and encode.
We change tinysql to the same way.