### PR TITLE
Enhencement:tablecodec/tablecodec.go/EncodeIndexSeekKey

### DIFF
--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -85,7 +85,7 @@ func appendTableIndexPrefix(buf []byte, tableID int64) []byte {
 
 // EncodeIndexSeekKey encodes an index value to kv.Key.
 func EncodeIndexSeekKey(tableID int64, idxID int64, encodedValue []byte) kv.Key {
-	key := make([]byte, 0, prefixLen+IdLen+len(encodedValue))
+	key := make([]byte, 0, prefixLen+idLen+len(encodedValue))
 	key = appendTableIndexPrefix(key, tableID)
 	key = codec.EncodeInt(key, idxID)
 	key = append(key, encodedValue...)

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -85,7 +85,7 @@ func appendTableIndexPrefix(buf []byte, tableID int64) []byte {
 
 // EncodeIndexSeekKey encodes an index value to kv.Key.
 func EncodeIndexSeekKey(tableID int64, idxID int64, encodedValue []byte) kv.Key {
-	key := make([]byte, 0, prefixLen+len(encodedValue))
+	key := make([]byte, 0, prefixLen+IdLen+len(encodedValue))
 	key = appendTableIndexPrefix(key, tableID)
 	key = codec.EncodeInt(key, idxID)
 	key = append(key, encodedValue...)


### PR DESCRIPTION
### This PR improve EncodeIndexSeekKey with allocating enough space for the key:
- currently the key was allocated with some space at first, which is not enough for the total things
- that works ok, but it means there will have another allocating and copy when append encodedValue
- so i change the size of space allocated at first to avoid reallocating and finally improve performance