### PR TITLE
parser: FIX the problem of `make clean` removes files other than generated parser.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ testSuite:
 clean:
 	$(GO) clean -i ./...
 	rm -rf *.out
-	rm -rf parser
+	cd parser && make clean
 
 # Split tests for CI to run `make test` in parallel.
 test: test_part_1 test_part_2


### PR DESCRIPTION
`make clean` removes the entire 'parser' directory, after which we need to restore the missing required files with `git` command. Actually, we just need to invoke `make clean` under the 'parser' directory instead