### PR TITLE
fix: vectorized func return true

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -81,7 +81,7 @@ func (b *builtinStrcmpSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 }
 
 func (b *builtinLengthSig) vectorized() bool {
-	return false
+	return true
 }
 
 // vecEvalInt evaluates a builtinLengthSig.


### PR DESCRIPTION
The vectorized func of builtinLengthSig should be set to true, otherwise the code will not be able to pass test.

If this is part of Project, it should be marked as TODO or anything else instead of nothing. But I don't see the value of coding this so I consider it as a bug.