### PR TITLE
fix(parser): fix go test error on parser (#70)

### DIFF
--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -196,7 +196,7 @@ func (s *testLexerSuite) TestscanString(c *C) {
 		{`' \n\tTest String'`, " \n\tTest String"},
 		{`'\x\B'`, "xB"},
 		{`'\0\'\"\b\n\r\t\\'`, "\000'\"\b\n\r\t\\"},
-		{`'\Z'`, string(26)},
+		{`'\Z'`, string(rune(26))},
 		{`'\%\_'`, `\%\_`},
 		{`'hello'`, "hello"},
 		{`'"hello"'`, `"hello"`},


### PR DESCRIPTION
golang/go#32479 removed the explicit type conversion `string(i)` where `i` has an integer type other than `rune` in `go 1.15`. 

That is a **backward incompatible** change.

Fix #70.