### PR TITLE
Fix TestLockTTL

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -237,7 +237,7 @@ func txnLockTTL(startTime time.Time, txnSize int) uint64 {
 	// Increase lockTTL by the transaction's read time.
 	// When resolving a lock, we compare current ts and startTS+lockTTL to decide whether to clean up. If a txn
 	// takes a long time to read, increasing its TTL will help to prevent it from been aborted soon after prewrite.
-	elapsed := time.Since(startTime) / time.Millisecond
+	elapsed := time.Since(startTime) / elapsedUnit
 	return lockTTL + uint64(elapsed)
 }
 

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 	"sync"
+	"time"
 )
 
 // ResolvedCacheSize is max number of cached txn status.
@@ -101,6 +102,9 @@ var maxLockTTL uint64 = 120000
 
 // ttl = ttlFactor * sqrt(writeSizeInMiB)
 var ttlFactor = 6000
+
+// unit of elapsed time for increasing ttl
+var elapsedUnit = time.Millisecond
 
 // Lock represents a lock from tikv server.
 type Lock struct {


### PR DESCRIPTION
fix #122 

1. Add `elapsedUnit` for ease of correcting calculation of TTL in `TestLockTTL` without effect on other implementations
2. Convert x and y to `float64` ahead of subtraction in `ttlEquals`