### PR TITLE
fix default unsigned integers judgment

### DIFF
--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -290,7 +290,7 @@ func (s *testLockSuite) mustGetLock(c *C, key []byte) *Lock {
 func (s *testLockSuite) ttlEquals(c *C, x, y uint64) {
 	// NOTE: On ppc64le, all integers are by default unsigned integers,
 	// hence we have to separately cast the value returned by "math.Abs()" function for ppc64le.
-	if runtime.GOARCH == "ppc64le" {
+	if runtime.GOARCH == "ppc64le" || runtime.GOARCH == "arm64" {
 		c.Assert(int(-math.Abs(float64(x-y))), LessEqual, 2)
 	} else {
 		c.Assert(int(math.Abs(float64(x-y))), LessEqual, 2)


### PR DESCRIPTION
### What problem does this PR solve?

- I am using Apple M1 (GOARCH="arm64"; GOOS="darwin"; GOVERSION="go1.18.3") to test the proj6 but failed to pass the only case TestLockTTL.
- The testLockSuite function ttlEquals should be set true when the arch is arm64, otherwise, the code will not be able to pass the test locally, although it works well on the Autograding machine.

### What is changed and how it works?

I have written a demo as follows.

```go
func main() {
    fmt.Printf("runtime.GOARCH: %s\n", runtime.GOARCH)
    var x, y uint64 = 73, 1040
    fmt.Printf("x: %d, y: %d\n", x, y)
    fmt.Printf("int(math.Abs(float64(x-y))): %d\n", int(math.Abs(float64(x-y))))
    fmt.Printf("int(-math.Abs(float64(x-y))): %d\n", int(-math.Abs(float64(x-y))))
}
```

It will get different results depending on whether the system is arm64 or amd64.

```
// in GOARCH="amd64" GOOS="linux"
runtime.GOARCH: amd64
x: 73, y: 1040
int(-math.Abs(float64(x-y))): -9223372036854775808
int(math.Abs(float64(x-y))): -9223372036854775808

// in GOARCH="arm64" GOOS="darwin"
runtime.GOARCH: arm64
x: 73, y: 1040
int(-math.Abs(float64(x-y))): -9223372036854775808
// c.Assert(int(math.Abs(float64(x-y))), LessEqual, 2) will failed
int(math.Abs(float64(x-y))): 9223372036854775807
```

In order to avoid unnecessary misunderstandings among students using the MacBook with Apple silicon, I suggest adding a condition `runtime.GOARCH == "arm64"` to the judgment.